### PR TITLE
PR: DetachedInstanceError の修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ secrets.json
 
 input.csv
 windsurf.json
+data/

--- a/core/database_manager.py
+++ b/core/database_manager.py
@@ -1,5 +1,6 @@
 # データベースマネージャークラス
 
+import copy
 from sqlalchemy import create_engine, func
 from sqlalchemy.orm import sessionmaker, scoped_session
 from models.data_models import Base, Keyword, EbaySearchResult, SearchHistory, ExportHistory
@@ -121,7 +122,8 @@ class DatabaseManager:
             query = session.query(Keyword).filter(Keyword.status == status)
             if limit:
                 query = query.limit(limit)
-            return query.all()
+            result = copy.deepcopy(query.all())
+            return result
     
     # 検索結果の保存
     def save_search_results(self, keyword_id, results):


### PR DESCRIPTION
## 🔧 修正内容

### 問題の概要
`get_keywords()` メソッドで SQLAlchemy の `session_scope()` を使用し、`query.all()` で取得したオブジェクトに対して、with ブロックを抜けた後に属性へアクセスしようとすると、以下のエラーが発生しました。

```
sqlalchemy.orm.exc.DetachedInstanceError: Instance <Keyword at 0x1fba99afc10> is not bound to a Session; attribute refresh operation cannot proceed
```

これは、取得したオブジェクトが **Session にバインドされていない（Detached）状態** となるため、アクセスできなくなることが原因です。

### 変更前のコード
```python
query = session.query(Keyword).filter(Keyword.status == status)
if limit:
    query = query.limit(limit)
return query.all()
```

上記コードでは、`query.all()` によってデータが取得されますが、取得後に `session_scope()` の `with` ブロックを抜けると **session がクローズ** され、オブジェクトがデタッチされるため、その後の属性アクセスでエラーが発生していました。

### 変更後のコード
```python
import copy

query = session.query(Keyword).filter(Keyword.status == status)
if limit:
    query = query.limit(limit)
result = copy.deepcopy(query.all())
return result
```

### 修正のポイント
1. **`copy.deepcopy()` を使用**  
   - `query.all()` で取得したオブジェクトを `deepcopy()` することで、元の `session` とは無関係な完全なコピーを作成し、デタッチ状態でも安全にデータへアクセス可能に。

2. **他の代替案について**
   - `session.expunge_all()` を使用して、明示的にデタッチする方法も検討しましたが、他のデータの影響を受ける可能性があるため `deepcopy()` の方が安全と判断しました。
   - `session.commit()` してから `query.all()` を取得する方法もありますが、トランザクションの影響を考慮し、採用しませんでした。

---

## ✅ テスト内容

### 再現手順
1. `get_keywords()` を実行し、取得したオブジェクトの `keyword` 属性にアクセスする。
2. 修正前のコードでは `DetachedInstanceError` が発生。
3. 修正後のコードではエラーが発生せず、データが正しく取得できることを確認。

### テスト結果
- `query.all()` で取得したオブジェクトの `keyword`、`status` などの属性に対して、with ブロックの外でも正常にアクセスできることを確認。
- `copy.deepcopy()` により、元の `session` を閉じても影響がないことを確認。

---

## 🚀 影響範囲
- `get_keywords()` の挙動が変わるが、取得したデータの内容には影響なし。
- 取得したデータの変更が DB に反映されることはない（コピーのため）。

---

## 🔗 関連情報
- [[SQLAlchemy DetachedInstanceError](https://sqlalche.me/e/20/bhk3)](https://sqlalche.me/e/20/bhk3)
- [[Python Official: copy.deepcopy()](https://docs.python.org/ja/3/library/copy.html#copy.deepcopy)](https://docs.python.org/ja/3/library/copy.html#copy.deepcopy)