### PR TITLE
eBayの商品データ抽出に関する問題を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ secrets.json
 input.csv
 windsurf.json
 data/
+
+# windsurf rules
+.windsurfrules


### PR DESCRIPTION
## プルリクエストコメント

### 概要
このプルリクエストでは、eBayの商品データ抽出に関する問題を修正しました。特に以下の項目でデータが正しく取得されない問題に対応しました。

- **価格・通貨の取得の改善**
  - ドル（USD）以外に円（JPY）の対応を追加
  - カンマ付きの価格フォーマットに対応
- **送料の取得の改善**
  - JPY表記の送料データを取得可能に修正
- **出品者情報の取得の改善**
  - セレクターを `.s-item__seller-info-text` に変更し、出品者名・評価数・評価率を適切に取得
- **画像URLの取得の改善**
  - `s-item__image-img` から `.s-item__image-wrapper > img` にセレクターを変更し、画像URLが取得できるよう修正

### 変更内容の詳細

#### 価格と通貨の処理改善
**変更前:**
```python
price_match = re.search(r'\$(\d+\.?\d*)', price_text)
if price_match:
    item_data['price'] = float(price_match.group(1))
    item_data['currency'] = 'USD'
```

**変更後:**
```python
if '$' in price_text:  # ドルの場合
    price_match = re.search(r'\$(\d{1,3}(?:,\d{3})*\.\d{2})', price_text)
    if price_match:
        item_data['price'] = float(price_match.group(1).replace(',', ''))
        item_data['currency'] = 'USD'
else:  # 円の場合
    price_match = re.search(r'(\d{1,3}(?:,\d{3})*|\d+)\s*(?:円|JPY)', price_text)
    if price_match:
        item_data['price'] = float(price_match.group(1).replace(',', ''))
        item_data['currency'] = 'JPY'
```

#### 出品者情報の取得処理修正
**変更前:**
```python
seller_elem = item.query_selector('.s-item__seller-info')
```

**変更後:**
```python
seller_elem = item.query_selector('.s-item__seller-info-text')
```

- セレクターを `.s-item__seller-info-text` に変更
- 正規表現で **出品者名・評価数・評価率** を一括抽出する処理を追加

#### 画像URLの取得処理修正
**変更前:**
```python
img_elem = item.query_selector('.s-item__image-img')
```

**変更後:**
```python
img_elem = item.query_selector('.s-item__image-wrapper > img')
```

### レビュー観点
- [ ] 価格・送料・通貨が正しく抽出されるか
- [ ] 出品者情報の抽出が意図通り動作するか
- [ ] 画像URLの取得が正しく行われているか
- [ ] 変更による副作用が発生していないか

### その他
- **出品者情報の抽出に失敗するケース**がまだ存在する可能性があるため、さらなるデータ検証が必要です。
- **時間表記のパース処理**については現時点では変更なし。
- まだすべての要素が取得しきれていないので、**IssueはCloseしない**

この修正により、eBayの商品データ抽出の精度が向上することが期待されます。ご確認よろしくお願いいたします！

