### PR TITLE
refactor: Google Sheets APIの認証処理を統一化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ Thumbs.db
 # Secrets
 config.yaml
 secrets.json
+credentials.json
+.env
 
 
 input.csv

--- a/interfaces/sheets_interface.py
+++ b/interfaces/sheets_interface.py
@@ -25,7 +25,7 @@ class GoogleSheetsInterface:
             config_manager: 設定管理サービスのインスタンス
         """
         self.config = config_manager
-        self.credentials_path = self.config.get_from_env(self.config.get(['google_sheets', 'credentials_env']))
+        self.credentials_path = self.config.get(['google_sheets', 'credentials_path'])
         self.token_dir = self.config.get_path(['google_sheets', 'token_dir'])
         
         if self.token_dir is None:


### PR DESCRIPTION
refactor: Google Sheets APIの認証処理を統一化

## 変更内容

1. 認証処理の統一化
   - `GoogleSheetsInterface`クラスを活用して認証処理を統一
   - `keyword_manager.py`のGoogle Sheets関連コードを整理

2. インポート機能の追加
   - CLIコマンドに`google_sheets`形式のインポート機能を追加
   - 設定ファイルからスプレッドシートIDと範囲を取得

## 変更箇所

### 1. keyword_manager.py
```python
# 変更前
def import_from_google_sheets(self, spreadsheet_id, range_name):
    # Google Sheets APIを用いて
    credentials_path = self.config.get_from_env(self.config.get(['google_sheets', 'credentials_env']))
    if not credentials_path:
        logger.error("Google Sheets API認証情報が見つかりませんでした")
        return 0

    # ... 認証処理 ...

# 変更後
def import_from_google_sheets(self, spreadsheet_id, range_name):
    google_sheets = GoogleSheetsInterface(self.config)
    try:
        logger.info(f"Google Spreadsheetsからキーワードをインポート: {spreadsheet_id}")
        values = google_sheets.read_spreadsheet(spreadsheet_id, range_name)
        # ... 以降の処理 ...
```
### 2. cli_interface.py
```python
# 変更前
@app.command("import")
def import_keywords(
    file: Path = typer.Option(..., "--file", "-f", help="インポートするCSV/Excelファイルパス"),
    format: str = typer.Option("csv", "--format", "-t", help="ファイル形式（csv または excel）"),
    # ... その他のパラメータ ...
)

# 変更後
@app.command("import")
def import_keywords(
    format: str = typer.Option("csv", "--format", "-t", help="ファイル形式（csv, excel, google_sheets）"),
    file: Optional[Path] = typer.Option(None, "--file", "-f", help="インポートするCSV/Excelファイルパス（--formatがcsvまたはexcelの場合は必須）"),
    # ... その他のパラメータ ...
)
```

## テスト方法

### 認証処理のテスト
- Google Sheets APIの認証が正しく動作することを確認
- トークンの更新と保存が正しく行われることを確認

### インポート機能のテスト
- Google Sheetsからキーワードをインポートできることを確認
- エラーハンドリングが正しく動作することを確認

## 注意事項
- `credentials.json`は`.gitignore`に含まれているため、コミットされません
- スプレッドシートIDと範囲は環境変数または設定ファイルで設定する必要があります

### 連携するIssue
- #15

fixes #15