### PR TITLE
Fix #21: Add comprehensive eBay API response test fixtures

### DIFF
--- a/tests/integration/fixtures/ebay_responses/edge_cases_sample.json
+++ b/tests/integration/fixtures/ebay_responses/edge_cases_sample.json
@@ -1,0 +1,39 @@
+{
+  "empty_result": {
+    "items": [],
+    "total_entries": 0,
+    "filters": {}
+  },
+  "missing_fields": {
+    "item_id": "987654321098",
+    "title": "不完全なデータを含む商品",
+    "price": null,
+    "currency": "JPY",
+    "shipping_price": null,
+    "seller_name": "unknown_seller",
+    "listing_type": "fixed_price"
+  },
+  "special_characters": {
+    "item_id": "456789012345",
+    "title": "特殊文字テスト商品 ★☆♪♫&<>\"'",
+    "description": "改行\nタブ\t特殊文字©®™",
+    "price": 1234.56,
+    "currency": "JPY"
+  },
+  "extreme_values": {
+    "item_id": "567890123456",
+    "title": "極端な値を持つ商品",
+    "price": 999999999.99,
+    "shipping_price": 0.01,
+    "stock_quantity": 999999,
+    "seller_rating": 100.0,
+    "seller_feedback_count": 9999999
+  },
+  "unicode_content": {
+    "item_id": "678901234567",
+    "title": "マルチ言語商品名 - Multi-language Title - 多语言标题",
+    "description": "日本語の説明\nEnglish description\n中文说明",
+    "price": 2000.0,
+    "currency": "JPY"
+  }
+} 

--- a/tests/integration/fixtures/ebay_responses/error_response_samples.json
+++ b/tests/integration/fixtures/ebay_responses/error_response_samples.json
@@ -1,0 +1,35 @@
+{
+  "invalid_api_key": {
+    "error": {
+      "code": "1.1",
+      "message": "Invalid API Key",
+      "severity": "Error",
+      "category": "REQUEST"
+    }
+  },
+  "rate_limit_exceeded": {
+    "error": {
+      "code": "2.1",
+      "message": "Rate limit exceeded. Please try again later.",
+      "severity": "Error",
+      "category": "REQUEST"
+    }
+  },
+  "invalid_search_params": {
+    "error": {
+      "code": "3.1",
+      "message": "Invalid search parameters provided",
+      "severity": "Error",
+      "category": "REQUEST",
+      "parameters": ["keywords", "category_id"]
+    }
+  },
+  "service_unavailable": {
+    "error": {
+      "code": "4.1",
+      "message": "eBay service is temporarily unavailable",
+      "severity": "Error",
+      "category": "SYSTEM"
+    }
+  }
+} 

--- a/tests/integration/fixtures/ebay_responses/item_details_sample.json
+++ b/tests/integration/fixtures/ebay_responses/item_details_sample.json
@@ -1,0 +1,77 @@
+{
+  "item_id": "123456789012",
+  "title": "テスト商品 詳細情報",
+  "subtitle": "商品のサブタイトル情報",
+  "description": "これは商品の詳細な説明文です。\n複数行の説明文を含みます。\n商品の特徴や状態などが記載されています。",
+  "price": {
+    "value": 1999.99,
+    "currency": "JPY",
+    "original_price": 2499.99,
+    "discount_percentage": 20
+  },
+  "shipping": {
+    "cost": 500.0,
+    "service": "Standard",
+    "handling_time": 2,
+    "shipping_locations": ["JP", "US", "UK"],
+    "excluded_locations": ["AU", "NZ"]
+  },
+  "seller": {
+    "name": "test_seller_1",
+    "rating": 98.5,
+    "feedback_count": 1250,
+    "positive_feedback_percent": 99.1,
+    "store_name": "テストストア",
+    "store_url": "https://www.example.com/store/test_seller_1"
+  },
+  "listing": {
+    "type": "fixed_price",
+    "status": "active",
+    "condition": "new",
+    "condition_description": "新品・未使用",
+    "is_buy_it_now": true,
+    "quantity": {
+      "available": 10,
+      "sold": 5,
+      "total": 15
+    },
+    "start_time": "2023-12-01T00:00:00",
+    "end_time": "2023-12-31T23:59:59"
+  },
+  "categories": [
+    {
+      "id": "1234",
+      "name": "メインカテゴリ"
+    },
+    {
+      "id": "5678",
+      "name": "サブカテゴリ"
+    }
+  ],
+  "images": [
+    {
+      "url": "https://www.example.com/images/123456789012_1.jpg",
+      "type": "main"
+    },
+    {
+      "url": "https://www.example.com/images/123456789012_2.jpg",
+      "type": "gallery"
+    },
+    {
+      "url": "https://www.example.com/images/123456789012_3.jpg",
+      "type": "gallery"
+    }
+  ],
+  "item_specifics": {
+    "ブランド": "テストブランド",
+    "型番": "TEST-001",
+    "カラー": "ブラック",
+    "サイズ": "M"
+  },
+  "return_policy": {
+    "returns_accepted": true,
+    "return_period": 30,
+    "refund_method": "Money Back",
+    "shipping_cost_paid_by": "Buyer"
+  }
+} 

--- a/tests/integration/fixtures/ebay_responses/paginated_search_result.json
+++ b/tests/integration/fixtures/ebay_responses/paginated_search_result.json
@@ -1,0 +1,71 @@
+{
+  "pagination": {
+    "total_entries": 156,
+    "total_pages": 8,
+    "current_page": 1,
+    "entries_per_page": 20,
+    "has_next_page": true,
+    "next_page_token": "AoE/GhIQBhAKEAMQBRAIEAkQARAG"
+  },
+  "items": [
+    {
+      "item_id": "123456789012",
+      "title": "テスト商品 1",
+      "price": 1999.99,
+      "currency": "JPY",
+      "shipping_price": 500.0,
+      "stock_quantity": 10,
+      "seller_name": "test_seller_1",
+      "seller_rating": 98.5,
+      "seller_feedback_count": 1250,
+      "auction_end_time": "2023-12-31T23:59:59",
+      "listing_type": "fixed_price",
+      "condition": "new",
+      "is_buy_it_now": true,
+      "bids_count": 0,
+      "item_url": "https://www.example.com/item/123456789012",
+      "image_url": "https://www.example.com/images/123456789012.jpg"
+    },
+    {
+      "item_id": "234567890123",
+      "title": "テスト商品 2",
+      "price": 1500.0,
+      "currency": "JPY",
+      "shipping_price": 0.0,
+      "stock_quantity": 5,
+      "seller_name": "test_seller_2",
+      "seller_rating": 99.0,
+      "seller_feedback_count": 3500,
+      "auction_end_time": "2023-12-25T12:00:00",
+      "listing_type": "auction",
+      "condition": "used",
+      "is_buy_it_now": false,
+      "bids_count": 12,
+      "item_url": "https://www.example.com/item/234567890123",
+      "image_url": "https://www.example.com/images/234567890123.jpg"
+    }
+  ],
+  "filters": {
+    "applied_filters": {
+      "min_price": 1000,
+      "max_price": 5000,
+      "condition": ["new", "used"],
+      "listing_type": ["fixed_price", "auction"]
+    },
+    "available_filters": {
+      "categories": [
+        {"id": "1234", "name": "カテゴリ1", "count": 45},
+        {"id": "5678", "name": "カテゴリ2", "count": 32}
+      ],
+      "conditions": [
+        {"value": "new", "count": 89},
+        {"value": "used", "count": 67}
+      ],
+      "price_ranges": [
+        {"min": 0, "max": 1000, "count": 23},
+        {"min": 1000, "max": 5000, "count": 98},
+        {"min": 5000, "max": null, "count": 35}
+      ]
+    }
+  }
+} 

--- a/tests/integration/test_ebay_api_responses.py
+++ b/tests/integration/test_ebay_api_responses.py
@@ -1,0 +1,110 @@
+import json
+import os
+import pytest
+from pathlib import Path
+
+# フィクスチャファイルのパスを設定
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "ebay_responses"
+
+def load_fixture(filename):
+    """フィクスチャファイルを読み込む"""
+    with open(FIXTURES_DIR / filename, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+class TestEbayApiResponses:
+    def test_search_result_parsing(self):
+        """基本的な検索結果のパース処理をテスト"""
+        data = load_fixture("search_result_sample.json")
+        assert isinstance(data, list)
+        assert len(data) == 3
+        
+        # 最初の商品のデータ構造を検証
+        item = data[0]
+        assert isinstance(item["item_id"], str)
+        assert isinstance(item["price"], (int, float))
+        assert isinstance(item["shipping_price"], (int, float))
+        assert isinstance(item["seller_rating"], (int, float))
+        assert isinstance(item["seller_feedback_count"], int)
+
+    def test_item_details_parsing(self):
+        """商品詳細情報のパース処理をテスト"""
+        data = load_fixture("item_details_sample.json")
+        
+        # 基本情報の検証
+        assert data["item_id"] == "123456789012"
+        assert isinstance(data["price"], dict)
+        assert isinstance(data["shipping"], dict)
+        assert isinstance(data["seller"], dict)
+        
+        # ネストされた情報の検証
+        assert len(data["categories"]) == 2
+        assert len(data["images"]) == 3
+        assert isinstance(data["item_specifics"], dict)
+        assert isinstance(data["return_policy"], dict)
+
+    def test_paginated_search_result(self):
+        """ページネーション付き検索結果のパース処理をテスト"""
+        data = load_fixture("paginated_search_result.json")
+        
+        # ページネーション情報の検証
+        assert "pagination" in data
+        pagination = data["pagination"]
+        assert pagination["total_entries"] > 0
+        assert pagination["current_page"] == 1
+        assert pagination["has_next_page"] is True
+        
+        # 商品リストの検証
+        assert len(data["items"]) > 0
+        
+        # フィルター情報の検証
+        assert "filters" in data
+        assert "applied_filters" in data["filters"]
+        assert "available_filters" in data["filters"]
+
+    def test_error_responses(self):
+        """エラーレスポンスのパース処理をテスト"""
+        data = load_fixture("error_response_samples.json")
+        
+        # 各種エラーパターンの検証
+        assert "invalid_api_key" in data
+        assert "rate_limit_exceeded" in data
+        assert "invalid_search_params" in data
+        assert "service_unavailable" in data
+        
+        # エラー構造の検証
+        for error_type in data.values():
+            assert "error" in error_type
+            assert "code" in error_type["error"]
+            assert "message" in error_type["error"]
+            assert "severity" in error_type["error"]
+            assert "category" in error_type["error"]
+
+    def test_edge_cases(self):
+        """エッジケースのパース処理をテスト"""
+        data = load_fixture("edge_cases_sample.json")
+        
+        # 空の検索結果
+        assert len(data["empty_result"]["items"]) == 0
+        
+        # 欠損フィールド
+        missing = data["missing_fields"]
+        assert missing["price"] is None
+        assert missing["shipping_price"] is None
+        
+        # 特殊文字
+        special = data["special_characters"]
+        assert "&<>\"'" in special["title"]
+        assert "\n" in special["description"]
+        assert "\t" in special["description"]
+        
+        # 極端な値
+        extreme = data["extreme_values"]
+        assert extreme["price"] > 999999
+        assert extreme["shipping_price"] < 0.1
+        assert extreme["stock_quantity"] > 999998
+        
+        # Unicode文字
+        unicode = data["unicode_content"]
+        assert "Multi-language" in unicode["title"]
+        assert "中文" in unicode["title"]
+        assert "日本語" in unicode["description"] 


### PR DESCRIPTION
# eBay API 応答の統合テストフィクスチャの追加

## 概要

Issue #21 で指摘されていた「eBay API 応答の統合テストフィクスチャが不足している」という問題に対応し、包括的なテストフィクスチャと統合テストを追加しました。

## 変更内容

### 新規フィクスチャファイルの追加

1. `error_response_samples.json`

   - API 認証エラー
   - レート制限エラー
   - 無効なパラメータエラー
   - サービス停止エラー

2. `item_details_sample.json`

   - 商品の詳細情報
   - 価格情報
   - 配送情報
   - 出品者情報
   - カテゴリ情報
   - 画像情報
   - 商品固有の属性
   - 返品ポリシー

3. `paginated_search_result.json`

   - ページネーション情報
   - 商品リスト
   - 適用済みフィルター
   - 利用可能なフィルター

4. `edge_cases_sample.json`
   - 空の検索結果
   - 欠損フィールド
   - 特殊文字を含むデータ
   - 極端な値
   - マルチ言語コンテンツ

### 統合テストの実装

- 基本的な検索結果のパース処理テスト
- 商品詳細情報のパース処理テスト
- ページネーション付き検索結果のパース処理テスト
- エラーレスポンスのパース処理テスト
- エッジケースのパース処理テスト

## テスト結果

- 全ての新規テストが正常に実行されることを確認済み
- 既存のテストへの影響なし

## レビューのポイント

- フィクスチャの網羅性
- テストケースの妥当性
- エッジケースの考慮
- コードの可読性

## 関連 Issue

Closes #21
