### PR TITLE
GitHub Actionsワークフローのテストパイプライン改善

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,11 +9,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     strategy:
       matrix:
         python-version: [3.8, 3.9, "3.10"]
+      fail-fast: false # 1つのバージョンが失敗しても他は継続
 
     steps:
       - uses: actions/checkout@v3
@@ -22,6 +23,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip" # 依存関係のキャッシュを有効化
 
       - name: Install dependencies
         run: |
@@ -30,13 +32,24 @@ jobs:
 
       - name: Run unit tests
         run: |
-          pytest tests/unit/ --cov=. --cov-report=xml
+          pytest tests/unit/ --cov=. --cov-report=xml -v
 
       - name: Run integration tests
         run: |
-          pytest tests/integration/ --cov=. --cov-report=xml --cov-append
+          pytest tests/integration/ --cov=. --cov-report=xml --cov-append -v
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
+          fail_ci_if_error: false # カバレッジアップロードの失敗でCIを失敗させない
+
+      - name: Upload test logs
+        if: always() # テストが失敗しても実行
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-logs-python-${{ matrix.python-version }}
+          path: |
+            .pytest_cache/
+            htmlcov/
+            *.log


### PR DESCRIPTION
# GitHub Actions ワークフローのテストパイプライン改善

## 変更内容

この PR では、GitHub Actions のテストパイプラインを以下の点で改善しています：

1. テストの詳細なフィードバック強化

   - pytest に`-v`オプションを追加
   - より詳細なテスト結果の表示が可能に

2. マトリックスビルドの信頼性向上

   - `fail-fast: false`を設定
   - 1 つの Python バージョンでテストが失敗しても他のバージョンのテストを継続
   - タイムアウト時間を 15 分に延長

3. ビルドの効率化

   - `pip`のキャッシュ機能を有効化
   - 依存関係のインストール時間を短縮
   - ネットワーク帯域の使用を最適化

4. デバッグ情報の充実
   - テストログをアーティファクトとして保存
   - テスト失敗時の調査が容易に
   - カバレッジレポートのアップロード失敗時に CI を失敗させない設定を追加

## テスト結果

- 現在のテストスイートに一部失敗があります（Issue #41 で追跡中）
- これらの問題は本 PR の変更とは独立しており、別途対応予定です

## レビューのポイント

- [ ] タイムアウト時間の設定（15 分）は適切か
- [ ] アーティファクトの保存対象は十分か
- [ ] キャッシュの設定は適切か

## 関連 Issue

Closes #20
