### PR TITLE
Fix #62: 検索コマンドの残り時間計算でゼロ除算エラーが発生する問題

### DIFF
--- a/interfaces/cli_interface.py
+++ b/interfaces/cli_interface.py
@@ -137,7 +137,7 @@ def search_keywords(
                 # 残り時間を計算
                 elapsed = time.time() - start_time
                 if i > 0:  # 最初のキーワード以降で残り時間を計算
-                    items_per_sec = i / elapsed
+                    items_per_sec = i / elapsed if elapsed > 0 else 0
                     remaining_items = len(keywords) - i
                     remaining_seconds = remaining_items / items_per_sec if items_per_sec > 0 else 0
                     


### PR DESCRIPTION
## 概要
検索コマンド実行時の残り時間計算処理において、処理時間が極端に短い場合に発生するゼロ除算エラーを修正しました。

## 変更内容
- `interfaces/cli_interface.py` の `search_keywords` 関数内で、経過時間が0の場合に0で除算しないよう条件分岐を追加
- 処理時間を計算する際に経過時間が0の場合は0を返すよう修正
- テストが正常に通過することを確認済み

## テスト結果
- 以下のテストを実行し、正常に通過することを確認しました：
  - `tests/integration/test_cli_interface_integration.py::TestCliInterfaceIntegration::test_search_command`
  - `tests/unit/test_cli_interface.py::test_search_keywords`

## 関連Issue
- closes #62 